### PR TITLE
Fixed display_heatmap

### DIFF
--- a/keract/keract.py
+++ b/keract/keract.py
@@ -202,4 +202,3 @@ def display_gradients_of_trainable_weights(gradients, save=False):
         else:
             plt.show()
         plt.close(fig)
-        

--- a/keract/keract.py
+++ b/keract/keract.py
@@ -201,5 +201,5 @@ def display_gradients_of_trainable_weights(gradients, save=False):
             plt.savefig(layer_name.split('/')[0] + '.png', bbox_inches='tight')
         else:
             plt.show()
-         plt.close(fig)
+        plt.close(fig)
         

--- a/keract/keract.py
+++ b/keract/keract.py
@@ -121,11 +121,11 @@ def display_activations(activations, cmap=None, save=False):
         plt.close(fig)
 
 
-def display_heatmaps(activations, image, save=False):
+def display_heatmaps(activations, input_image, save=False):
     """
     Plot heatmaps of activations for all filters overlayed on the input image for each layer
     :param activations: dict mapping layers to corresponding activations (1, output_h, output_w, num_filters)
-    :param image: input image for the overlay
+    :param input_image: input image for the overlay
     :param save: bool- if the plot should be saved
     :return: None
     """
@@ -155,11 +155,11 @@ def display_heatmaps(activations, image, save=False):
                 img = acts[0, :, :, i]
                 # scale the activations (which will form our heat map) to be in range 0-1
                 img = scaler.transform(img)
-                # resize heatmap to be same dimensions of image
+                # resize heatmap to be same dimensions of input_image
                 img = Image.fromarray(img)
-                img = img.resize((image.shape[0], image.shape[1]), Image.BILINEAR)
+                img = img.resize((input_image.shape[0], input_image.shape[1]), Image.BILINEAR)
                 img = np.array(img)
-                axes.flat[i].imshow(img / 255.0)
+                axes.flat[i].imshow(input_image / 255.0)
                 # overlay a 70% transparent heat map onto the image
                 # Lowest activations are dark, highest are dark red, mid are yellow
                 axes.flat[i].imshow(img, alpha=0.3, cmap='jet', interpolation='bilinear')


### PR DESCRIPTION
Sorry to bombard you with PRs
After updating my installed version of keract and testing it following my previous pull request I noticed that #29 changed plt.imshow(image / 255.0) to axes.flat[i].imshow(img / 255.0) presumably due to confusion over the fact that img is the activations whereas image is the inputed image so I've renamed image to input_image to avoid future confusion.