### PR TITLE
PR to Make display_activations work for conv layers with only one filter

### DIFF
--- a/keract/keract.py
+++ b/keract/keract.py
@@ -103,7 +103,7 @@ def display_activations(activations, cmap=None, save=False):
         print('')
         nrows = int(math.sqrt(acts.shape[-1]) - 0.001) + 1  # best square fit for the given number
         ncols = int(math.ceil(acts.shape[-1] / nrows))
-        fig, axes = plt.subplots(nrows, ncols, figsize=(12, 12))
+        fig, axes = plt.subplots(nrows, ncols, squeeze=False, figsize=(12, 12))
         fig.suptitle(layer_name)
         for i in range(nrows * ncols):
             if i < acts.shape[-1]:


### PR DESCRIPTION
axes.flat fails for conv layers with only one filter as the single subplot can't be flattened. I have fixed this by passing squeeze=False to plt.subplots to stop it from removing the redundant dimensions from the numpy array it creates as mentioned in [https://stackoverflow.com/questions/55305149/python-subplot-used-to-show-one-figure](https://stackoverflow.com/questions/55305149/python-subplot-used-to-show-one-figure)