### PR TITLE
Removed keras and tensorflow requirement and updated to tf.keras

### DIFF
--- a/examples/data.py
+++ b/examples/data.py
@@ -1,5 +1,5 @@
-import keras
-from keras.datasets import mnist
+import tensorflow.keras as keras
+from tensorflow.keras.datasets import mnist
 
 
 class MNIST:

--- a/examples/dump_activations_to_disk.py
+++ b/examples/dump_activations_to_disk.py
@@ -1,6 +1,6 @@
 import numpy as np
-from keras import Sequential
-from keras.layers import Dropout, Dense
+from tensorflow.keras import Sequential
+from tensorflow.keras.layers import Dropout, Dense
 
 from keract import get_activations, persist_to_json_file, load_activations_from_json_file
 

--- a/examples/dump_activations_to_disk.py
+++ b/examples/dump_activations_to_disk.py
@@ -1,28 +1,37 @@
 import numpy as np
+import tensorflow as tf
 from tensorflow.keras import Sequential
 from tensorflow.keras.layers import Dropout, Dense
 
 from keract import get_activations, persist_to_json_file, load_activations_from_json_file
 
-# define the model.
-model = Sequential()
-model.add(Dense(16, input_shape=(10,)))
-model.add(Dropout(0.5))
-model.add(Dense(10, activation='softmax'))
-model.compile(optimizer='adam', loss='categorical_crossentropy')
+if __name__ == "__main__":
+    # Check for GPUs and set them to dynamically grow memory as needed
+    # Avoids OOM from tensorflow greedily allocating GPU memory
+    physical_devices = tf.config.list_physical_devices('GPU')
+    if physical_devices:
+        for dev in physical_devices:
+            tf.config.experimental.set_memory_growth(dev, True)
 
-# fetch activations.
-x = np.ones((2, 10))
-activations = get_activations(model, x)
+    # define the model.
+    model = Sequential()
+    model.add(Dense(16, input_shape=(10,)))
+    model.add(Dropout(0.5))
+    model.add(Dense(10, activation='softmax'))
+    model.compile(optimizer='adam', loss='categorical_crossentropy')
 
-# persist the activations to the disk.
-output = 'activations.json'
-persist_to_json_file(activations, output)
+    # fetch activations.
+    x = np.ones((2, 10))
+    activations = get_activations(model, x)
 
-# read them from the disk.
-activations2 = load_activations_from_json_file(output)
+    # persist the activations to the disk.
+    output = 'activations.json'
+    persist_to_json_file(activations, output)
 
-# print them.
-print(list(activations.keys()))
-print(list(activations2.keys()))
-print('Dumped to {}.'.format(output))
+    # read them from the disk.
+    activations2 = load_activations_from_json_file(output)
+
+    # print them.
+    print(list(activations.keys()))
+    print(list(activations2.keys()))
+    print('Dumped to {}.'.format(output))

--- a/examples/heat_map.py
+++ b/examples/heat_map.py
@@ -3,10 +3,10 @@ from io import BytesIO
 import numpy as np
 import requests
 from PIL import Image
-from keras.applications.vgg16 import VGG16
-from keras.applications.vgg16 import decode_predictions
-from keras.applications.vgg16 import preprocess_input
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.applications.vgg16 import VGG16
+from tensorflow.keras.applications.vgg16 import decode_predictions
+from tensorflow.keras.applications.vgg16 import preprocess_input
+from tensorflow.keras.preprocessing.image import img_to_array
 
 import keract
 

--- a/examples/heat_map.py
+++ b/examples/heat_map.py
@@ -3,6 +3,7 @@ from io import BytesIO
 import numpy as np
 import requests
 from PIL import Image
+import tensorflow as tf
 from tensorflow.keras.applications.vgg16 import VGG16
 from tensorflow.keras.applications.vgg16 import decode_predictions
 from tensorflow.keras.applications.vgg16 import preprocess_input
@@ -10,23 +11,32 @@ from tensorflow.keras.preprocessing.image import img_to_array
 
 import keract
 
-model = VGG16()
+if __name__ == "__main__":
+    # Check for GPUs and set them to dynamically grow memory as needed
+    # Avoids OOM from tensorflow greedily allocating GPU memory
+    physical_devices = tf.config.list_physical_devices('GPU')
+    if physical_devices:
+        for dev in physical_devices:
+            tf.config.experimental.set_memory_growth(dev, True)
+    model = VGG16()
 
-url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Gatto_europeo4.jpg/250px-Gatto_europeo4.jpg'
-response = requests.get(url)
-image = Image.open(BytesIO(response.content))
-image = image.crop((0, 0, 224, 224))
-image = img_to_array(image)
-arr_image = np.array(image)
-image = image.reshape((1, image.shape[0], image.shape[1], image.shape[2]))
-image = preprocess_input(image)
-yhat = model.predict(image)
-label = decode_predictions(yhat)
-label = label[0][0]
-print('{} ({})'.format(label[1], label[2] * 100))
+    url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Gatto_' \
+          'europeo4.jpg/250px-Gatto_europeo4.jpg'
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = image.crop((0, 0, 224, 224))
+    image = img_to_array(image)
+    arr_image = np.array(image)
+    image = image.reshape((1, image.shape[0], image.shape[1], image.shape[2]))
+    image = preprocess_input(image)
+    yhat = model.predict(image)
+    label = decode_predictions(yhat)
+    label = label[0][0]
+    print('{} ({})'.format(label[1], label[2] * 100))
 
-model.compile(optimizer='adam',
-              loss='categorical_crossentropy',
-              metrics=['accuracy'])
-activations = keract.get_activations(model, image, layer_name='block1_conv1')
-keract.display_heatmaps(activations, arr_image, save=True)
+    model.compile(optimizer='adam',
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+    activations = keract.get_activations(model, image,
+                                         layer_name='block1_conv1')
+    keract.display_heatmaps(activations, arr_image, save=True)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -3,11 +3,11 @@ from __future__ import print_function
 import os
 from glob import glob
 
-import keras
-from keras.callbacks import ModelCheckpoint
-from keras.layers import Conv2D, MaxPooling2D
-from keras.layers import Dense, Dropout, Flatten
-from keras.models import Sequential
+import tensorflow.keras as keras
+from tensorflow.keras.callbacks import ModelCheckpoint
+from tensorflow.keras.layers import Conv2D, MaxPooling2D
+from tensorflow.keras.layers import Dense, Dropout, Flatten
+from tensorflow.keras.models import Sequential
 
 import keract
 import utils

--- a/examples/multi_inputs.py
+++ b/examples/multi_inputs.py
@@ -1,6 +1,6 @@
 import numpy as np
-from keras.layers import Add, Dense
-from keras.models import Input, Model
+from tensorflow.keras.layers import Add, Dense
+from tensorflow.keras.models import Input, Model
 
 import keract
 import utils

--- a/examples/multi_inputs.py
+++ b/examples/multi_inputs.py
@@ -1,6 +1,6 @@
 import numpy as np
-from tensorflow.keras.layers import Add, Dense
-from tensorflow.keras.models import Input, Model
+from tensorflow.keras.layers import Add, Dense, Input
+from tensorflow.keras.models import Model
 
 import keract
 import utils

--- a/examples/recurrent.py
+++ b/examples/recurrent.py
@@ -1,6 +1,7 @@
+import tensorflow as tf
 import tensorflow.keras as keras
 from tensorflow.keras.layers import Dense
-from tensorflow.keras.layers.recurrent import LSTM
+from tensorflow.keras.layers import LSTM
 from tensorflow.keras.models import Sequential
 
 import keract
@@ -8,6 +9,13 @@ import utils
 from data import MNIST
 
 if __name__ == '__main__':
+    # Check for GPUs and set them to dynamically grow memory as needed
+    # Avoids OOM from tensorflow greedily allocating GPU memory
+    physical_devices = tf.config.list_physical_devices('GPU')
+    if physical_devices:
+        for dev in physical_devices:
+            tf.config.experimental.set_memory_growth(dev, True)
+
     x_train, y_train, _, _ = MNIST.get_mnist_data()
 
     # (60000, 28, 28, 1) to ((60000, 28, 28)

--- a/examples/recurrent.py
+++ b/examples/recurrent.py
@@ -1,7 +1,7 @@
-import keras
-from keras.layers import Dense
-from keras.layers.recurrent import LSTM
-from keras.models import Sequential
+import tensorflow.keras as keras
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.layers.recurrent import LSTM
+from tensorflow.keras.models import Sequential
 
 import keract
 import utils

--- a/examples/vgg16.py
+++ b/examples/vgg16.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 from tensorflow.keras.applications.vgg16 import VGG16
 from tensorflow.keras.applications.vgg16 import decode_predictions
 from tensorflow.keras.applications.vgg16 import preprocess_input
@@ -6,24 +7,31 @@ from PIL import Image
 import requests
 from io import BytesIO
 import keract
+if __name__ == "__main__":
+    # Check for GPUs and set them to dynamically grow memory as needed
+    # Avoids OOM from tensorflow greedily allocating GPU memory
+    physical_devices = tf.config.list_physical_devices('GPU')
+    if physical_devices:
+        for dev in physical_devices:
+            tf.config.experimental.set_memory_growth(dev, True)
+    model = VGG16()
 
-model = VGG16()
+    url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Gatto_' \
+          'europeo4.jpg/250px-Gatto_europeo4.jpg'
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = image.crop((0, 0, 224, 224))
+    image = img_to_array(image)
+    image = image.reshape((1, image.shape[0], image.shape[1], image.shape[2]))
+    image = preprocess_input(image)
+    yhat = model.predict(image)
+    label = decode_predictions(yhat)
+    label = label[0][0]
+    print('{} ({})'.format(label[1], label[2] * 100))
 
-url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Gatto_europeo4.jpg/250px-Gatto_europeo4.jpg'
-response = requests.get(url)
-image = Image.open(BytesIO(response.content))
-image = image.crop((0, 0, 224, 224))
-image = img_to_array(image)
-image = image.reshape((1, image.shape[0], image.shape[1], image.shape[2]))
-image = preprocess_input(image)
-yhat = model.predict(image)
-label = decode_predictions(yhat)
-label = label[0][0]
-print('{} ({})'.format(label[1], label[2] * 100))
-
-model.compile(optimizer='adam',
-              loss='categorical_crossentropy',
-              metrics=['accuracy'])
-activations = keract.get_activations(model, image)
-first = activations.get('block1_conv1/Relu:0')
-keract.display_activations(activations)
+    model.compile(optimizer='adam',
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+    activations = keract.get_activations(model, image)
+    first = activations.get('block1_conv1/Relu:0')
+    keract.display_activations(activations)

--- a/examples/vgg16.py
+++ b/examples/vgg16.py
@@ -1,7 +1,7 @@
-from keras.applications.vgg16 import VGG16
-from keras.applications.vgg16 import decode_predictions
-from keras.applications.vgg16 import preprocess_input
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.applications.vgg16 import VGG16
+from tensorflow.keras.applications.vgg16 import decode_predictions
+from tensorflow.keras.applications.vgg16 import preprocess_input
+from tensorflow.keras.preprocessing.image import img_to_array
 from PIL import Image
 import requests
 from io import BytesIO

--- a/keract/__init__.py
+++ b/keract/__init__.py
@@ -1,8 +1,9 @@
 import importlib
+
 tf_spec = importlib.util.find_spec("tensorflow")
 if tf_spec is None:
-   raise ImportError("No valid tensorflow installation found. Please install "
-                     "tensorflow>=2.0 or tensorflow-gpu>=2.0")
+    raise ImportError("No valid tensorflow installation found. Please install "
+                      "tensorflow>=2.0 or tensorflow-gpu>=2.0")
 
 from keract.keract import display_activations  # noqa
 from keract.keract import display_gradients_of_trainable_weights  # noqa

--- a/keract/__init__.py
+++ b/keract/__init__.py
@@ -1,8 +1,8 @@
-try:
-   import tensorflow
-except ImportError:
-   print("No valid tensorflow installation found. Please install "
-         "tensorflow>=2.0 or tensorflow-gpu>=2.0")
+import importlib
+tf_spec = importlib.util.find_spec("tensorflow")
+if tf_spec is None:
+   raise ImportError("No valid tensorflow installation found. Please install "
+                     "tensorflow>=2.0 or tensorflow-gpu>=2.0")
 
 from keract.keract import display_activations  # noqa
 from keract.keract import display_gradients_of_trainable_weights  # noqa

--- a/keract/__init__.py
+++ b/keract/__init__.py
@@ -1,3 +1,9 @@
+try:
+   import tensorflow
+except ImportError:
+   print("No valid tensorflow installation found. Please install "
+         "tensorflow>=2.0 or tensorflow-gpu>=2.0")
+
 from keract.keract import display_activations  # noqa
 from keract.keract import display_gradients_of_trainable_weights  # noqa
 from keract.keract import display_heatmaps  # noqa

--- a/keract/keract.py
+++ b/keract/keract.py
@@ -2,8 +2,8 @@ import json
 import os
 from collections import OrderedDict
 
-import keras.backend as K
-from keras.models import Model
+import tensorflow.keras.backend as K
+from tensorflow.keras.models import Model
 
 
 def n_(node, output_format_):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-Keras>=2.2.3
 numpy>=1.16.2
-tensorflow>=2.0
 h5py
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,5 @@ setup(
     packages=['keract'],
     install_requires=[
         'numpy>=1.16.2',
-        'keras>=2.3.1',
-        'tensorflow>=2.0',
     ]
 )

--- a/tests/display_activations_test.py
+++ b/tests/display_activations_test.py
@@ -2,10 +2,10 @@ import os
 import unittest
 from glob import glob
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 import numpy as np
-from keras import Input, Model
-from keras.layers import Dense
+from tensorflow.keras import Input, Model
+from tensorflow.keras.layers import Dense
 
 from keract import get_activations, display_activations
 

--- a/tests/get_activations_test.py
+++ b/tests/get_activations_test.py
@@ -1,9 +1,9 @@
 import unittest
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 import numpy as np
-from keras import Input, Model
-from keras.layers import Dense, concatenate
+from tensorflow.keras import Input, Model
+from tensorflow.keras.layers import Dense, concatenate
 
 from keract import get_activations, get_gradients_of_activations, get_gradients_of_trainable_weights
 

--- a/tests/get_activations_test.py
+++ b/tests/get_activations_test.py
@@ -8,10 +8,10 @@ from tensorflow.keras.layers import Dense, concatenate
 from keract import get_activations, get_gradients_of_activations, get_gradients_of_trainable_weights
 
 
-def dummy_model_and_inputs():
+def dummy_model_and_inputs(**kwargs):
     i1 = Input(shape=(10,), name='i1')
     a = Dense(1, name='fc1')(i1)
-    model = Model(inputs=[i1], outputs=[a])
+    model = Model(inputs=[i1], outputs=[a], **kwargs)
     x = np.random.uniform(size=(32, 10))
     return model, x
 
@@ -98,12 +98,11 @@ class GetActivationsTest(unittest.TestCase):
             np.testing.assert_almost_equal(n, s)
 
         self.assertListEqual(list(simple.keys()), ['i1', 'fc1'])
-        self.assertListEqual(list(full.keys()), ['i1:0', 'fc1/BiasAdd:0'])
+        self.assertListEqual(list(full.keys()), ['i1:0', 'fc1/Identity:0'])
         self.assertListEqual(list(numbered.keys()), [0, 1])
 
     def test_compile_vgg16_model(self):
-        model, x = dummy_model_and_inputs()
-        model.name = 'vgg16'  # spoof identity here!
+        model, x = dummy_model_and_inputs(name="vgg16")
         get_activations(model, x, auto_compile=False)
         self.assertTrue(model._is_compiled)
 

--- a/tests/persist_load_test.py
+++ b/tests/persist_load_test.py
@@ -1,10 +1,10 @@
 import os
 import unittest
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 import numpy as np
-from keras import Sequential
-from keras.layers import Dropout, Dense
+from tensorflow.keras import Sequential
+from tensorflow.keras.layers import Dropout, Dense
 
 from keract import get_activations, persist_to_json_file, load_activations_from_json_file
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = {py37}-tensorflow-2.0
 
 [testenv]
 deps = pytest
+       tensorflow >= 2.0
        -rrequirements.txt
        -rexamples/examples-requirements.txt
 changedir = examples


### PR DESCRIPTION
Requiring tensorflow as a dependency force installs the CPU only version of the package when users have tensorflow-gpu or nightly builds installed. Per https://github.com/tensorflow/tensorflow/issues/7166 we should avoid explicit tensorflow dependencies. Keras is also included with tensorflow now and need not be installed explicitly. 