### PR TITLE
Remove dependecy on scikit-learn and add option to produce a single heatmap per layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ keract.display_activations(activations, cmap=None, save=False, directory='.', da
 Plot the activations for each layer using matplotlib
 
 Inputs are:
-- `activations` dict - a dictionary mapping layers to their activations (the output of get_activations)
-- `cmap` (optional) string - a valid matplotlib colormap to be used
-- `save`(optional) a bool, if True the images of the activations are saved rather than being shown
+- `activations`: dict - a dictionary mapping layers to their activations (the output of get_activations)
+- `cmap`: (optional) string - a valid matplotlib colormap to be used
+- `save`: (optional) bool - if True the images of the activations are saved rather than being shown
 - `directory`: (optional) string - where to store the activations (if save is True)
-- `data_format`: (optional) tring - one of "channels_last" (default) or "channels_first".
+- `data_format`: (optional) string - one of "channels_last" (default) or "channels_first".
 - `reshape_1d_layers`: (optional) bool - tries to reshape large 1d layers to a square/rectangle.
 - `fig_size`: (optional) (float, float) - width, height in inches.
 
@@ -121,11 +121,11 @@ Plot heatmaps of activations for all filters overlayed on the input image for ea
 
 Inputs are:
 - `activations`: a dictionary mapping layers to their activations (the output of get_activations).
-- `input_image`:  numpy array of the image you inputed to the get_activations.
-- `directory`(optional) string - where to store the heatmaps (if save is True).
-- `save`(optional) bool - if True the heatmaps are saved rather than being shown.
+- `input_image`:  numpy array - the image that was passed as x to get_activations.
+- `directory`: (optional) string - where to store the heatmaps (if save is True).
+- `save`: (optional) bool - if True the heatmaps are saved rather than being shown.
 - `fix`: (optional) bool - if True automated checks and fixes for incorrect images will be ran.
-- `merge_filters`: (optional) bool - if True if one heatmap (with all the filters averaged together) is produced for each layer, if False a heatmap is produced for each filter in each layer
+- `merge_filters`: (optional) bool - if True one heatmap (with all the filters averaged together) is produced for each layer, if False a heatmap is produced for each filter in each layer
 
 ### Get gradients of weights
 
@@ -133,7 +133,7 @@ Inputs are:
 keract.get_gradients_of_trainable_weights(model, x, y)
 ```
 
-- `model` is a `keras.models.Model` object.
+- `model`: a `keras.models.Model` object.
 - `x`: Numpy array to feed the model as input. In the case of multi-inputs, `x` should be of type List.
 - `y`: Labels (numpy array). Keras convention.
 
@@ -145,7 +145,7 @@ The output is a dictionary mapping each trainable weight to the values of its gr
 keract.get_gradients_of_activations(model, x, y, layer_name=None, output_format='simple')
 ```
 
-- `model` is a `keras.models.Model` object.
+- `model`: a `keras.models.Model` object.
 - `x`: Numpy array to feed the model as input. In the case of multi-inputs, `x` should be of type List.
 - `y`: Labels (numpy array). Keras convention.
 - `layer_name`: (optional) Name of a layer for which activations should be returned.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The ordering of the dimensions in the inputs. "channels_last" corresponds to inp
 ### Display the activations as a heatmap overlaid on an image
 
 ```python
-keract.display_heatmaps(activations, input_image, save=False)
+keract.display_heatmaps(activations, input_image, directory='.', save=False, fix=True, merge_filters=False)
 ```
 
 Plot heatmaps of activations for all filters overlayed on the input image for each layer
@@ -122,9 +122,10 @@ Plot heatmaps of activations for all filters overlayed on the input image for ea
 Inputs are:
 - `activations`: a dictionary mapping layers to their activations (the output of get_activations).
 - `input_image`:  numpy array of the image you inputed to the get_activations.
-- `save`(optional) bool - if True the images of the activations are saved rather than being shown.
-- `fix`: (optional) bool - if automated checks and fixes for incorrect images should be run.
-- `directory`: string - where to store the activations (if save is True).
+- `directory`(optional) string - where to store the heatmaps (if save is True).
+- `save`(optional) bool - if True the heatmaps are saved rather than being shown.
+- `fix`: (optional) bool - if True automated checks and fixes for incorrect images will be ran.
+- `merge_filters`: (optional) bool - if True if one heatmap (with all the filters averaged together) is produced for each layer, if False a heatmap is produced for each filter in each layer
 
 ### Get gradients of weights
 

--- a/examples/examples-requirements.txt
+++ b/examples/examples-requirements.txt
@@ -1,4 +1,3 @@
 pillow
 requests
 matplotlib
-scikit-learn<=0.23.2

--- a/keract/keract.py
+++ b/keract/keract.py
@@ -460,7 +460,7 @@ def display_activations(activations, cmap=None, save=False, directory='.',
         plt.close(fig)
 
 
-def display_heatmaps(activations, input_image, directory='.', save=False, fix=True, merge_filters=False):
+def display_heatmaps(activations, input_image, directory='.', save=False, fix=True, merge_filters=False):  # noqa: C901
     """
     Plot heatmaps of activations for all filters overlayed on the input image for each layer
     :param activations: dict mapping layers to corresponding activations with the shape
@@ -483,7 +483,7 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
         :param arr: numpy array, the array to be scaled
         :return: numpy array
         """
-        scaled = arr * 1/(np.amax(arr) - np.amin(arr))
+        scaled = arr * (1/(np.amax(arr) - np.amin(arr)))
         scaled = scaled - np.amin(scaled)
         return scaled
 
@@ -498,7 +498,7 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
         # removes channels from the shape of grayscale images
         if len(input_image.shape) == 3 and input_image.shape[2] == 1:
             input_image = input_image.reshape(input_image.shape[0], input_image.shape[1])
-        #converts a 0-255 image to be 0-1
+        # converts a 0-255 image to be 0-1
         if np.amin(input_image) >= 0 and 1 < np.amax(input_image) <= 255:
             input_image /= 255.0
 
@@ -519,13 +519,13 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
         else:
             nrows = int(math.sqrt(acts.shape[-1]) - 0.001) + 1  # best square fit for the given number
             ncols = int(math.ceil(acts.shape[-1] / nrows))
-        
+
         fig, axes = plt.subplots(nrows, ncols, figsize=(12, 12))
         fig.suptitle(layer_name)
 
-        #loops over each subplot
+        # loops over each subplot
         for i in range(nrows * ncols):
-            #Hide the x-y axes of the plot as we aren't showing a graph
+            # Hide the x-y axes of the plot as we aren't showing a graph
             axes.flat[i].axis('off') if hasattr(axes, 'flat') else axes.axis('off')
 
             if merge_filters:
@@ -533,7 +533,7 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
                     img = acts[0, :, :]
                     # gets the activation of the ith layer
                     if data_format == 'channels_last':
-                        #normalise the activations of each neuron so they all contribute to the average equally
+                        # normalise the activations of each neuron so they all contribute to the average equally
                         for j in range(0, acts.shape[-1]):
                             img[:, j] = __scale(img[:, j])
                         img = np.sum(img, axis=1)
@@ -558,9 +558,9 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
                 else:
                     raise Exception('Expect a tensor of 3 or 4 dimensions.')
             else:
-                #if have reached a subplot that doesn't have an activation associated with it
+                # if have reached a subplot that doesn't have an activation associated with it
                 if i >= acts.shape[-1]:
-                    #if this was a break, the x-y axes wouldn't be hidden for the subsequent blank subplots
+                    # if this was a break, the x-y axes wouldn't be hidden for the subsequent blank subplots
                     continue
                 if len(acts.shape) == 3:
                     # gets the activation of the ith layer
@@ -579,7 +579,7 @@ def display_heatmaps(activations, input_image, directory='.', save=False, fix=Tr
                         raise Exception('Unknown data_format.')
                 else:
                     raise Exception('Expect a tensor of 3 or 4 dimensions.')
-            
+
             img = Image.fromarray(img)
             # resizes the overlay to be same dimensions of input_image
             img = img.resize((input_image.shape[1], input_image.shape[0]), Image.BILINEAR)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = {py3}-tensorflow-{2.3.0,2.4.0,2.5.0,2.6.2,2.7.0,2.8.0,2.9.0}
 
 [testenv]
+setenv =
+       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 deps = pytest
        -rrequirements.txt
        -rexamples/examples-requirements.txt


### PR DESCRIPTION
I'm happy to split this into two seperate PRs if you prefer.

9943b6e7513b31be84ede03f72fba6853225c44e removes the dependency on scikit-learn and hence fixes #137 and #146.\
6abf1d5bdc5b65c0fa3914a3d14a12824b970621 adds the option to produce a single heatmap for each layer (produced by taking the mean of the activations of the filters that make up the layer) as opposed to the default behaviour of producing a heatmap for each filter. 43a8e954f6aadf0c49889fc107e5cf8e2806b2d0 makes the API documentation generally more consistently formatted.