### PR TITLE
Update importlib import in __init__.py

### DIFF
--- a/keract/__init__.py
+++ b/keract/__init__.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 
 tf_spec = importlib.util.find_spec("tensorflow")
 if tf_spec is None:


### PR DESCRIPTION
I am getting ```AttributeError: module 'importlib' has no attribute 'util'``` when importing keract 4.5.1. I am using python 3.10.16. I found long running dicussion about importing util from importlib - it appears the proper way is:
```
import importlib.util
```
This fix works for me locally.
https://discuss.python.org/t/python3-11-importlib-no-longer-exposes-util/25641/8

If it's possible, please merge ASAP.
Best regards